### PR TITLE
add homebrew osx embedding and liboauth compiling

### DIFF
--- a/embed-osx-dep-homebrew.sh
+++ b/embed-osx-dep-homebrew.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# This script finds all of the dependecies from Fink and included them
+# into current folder so that it becomes a libdir to be installed into
+# ~/Library/Pd or /Library/Pd <hans@eds.org>
+
+if [ -z "$1" ]; then
+    PD_APP_LIB=`pwd`
+else
+    PD_APP_LIB=$1
+fi
+
+echo " "
+
+for pd_darwin in `find . -name '*.pd_darwin'`; do
+    LIBS=`otool -L $pd_darwin | sed -n 's|.*/usr/local/opt/\(.*\.dylib\).*|\1|p'`
+    if [ "x$LIBS" != "x" ]; then
+	echo "`echo $pd_darwin | sed 's|.*/\(.*\.pd_darwin$\)|\1|'` is using:"
+	for lib in $LIBS; do
+	    echo "    $lib"
+	    install -vp /usr/local/opt/$lib $PD_APP_LIB
+	    new_lib=`echo $lib | sed 's|.*/\(.*\.dylib\)|\1|'`
+	    install_name_tool -id @loader_path/$new_lib $PD_APP_LIB/$new_lib
+	    install_name_tool -change /usr/local/opt/$lib @loader_path/$new_lib $pd_darwin
+	done
+	echo " "
+    fi
+done
+
+for dylib in $PD_APP_LIB/*.dylib; do
+    LIBS=`otool -L $dylib | sed -n 's|.*/usr/local/opt/\(.*\.dylib\).*|\1|p'`
+    if [ "x$LIBS" != "x" ]; then
+	echo "`echo $dylib | sed 's|.*/\(.*\.dylib\)|\1|'` is using:"
+	for lib in $LIBS; do
+	    echo "    $lib"
+	    new_lib=`echo $lib | sed 's|.*/\(.*\.dylib\)|\1|'`
+	    if [ -e  $PD_APP_LIB/$new_lib ]; then
+		echo "$PD_APP_LIB/$new_lib already exists, skipping copy."
+	    else
+		install -vp /usr/local/opt/$lib $PD_APP_LIB
+	    fi
+	    install_name_tool -id @loader_path/$new_lib $PD_APP_LIB/$new_lib
+	    install_name_tool -change /usr/local/opt/$lib @loader_path/$new_lib $dylib
+	done
+	echo " "
+    fi
+done
+
+# run it one more time to catch dylibs that depend on dylibs
+for dylib in $PD_APP_LIB/*.dylib; do
+    LIBS=`otool -L $dylib | sed -n 's|.*/usr/local/opt/\(.*\.dylib\).*|\1|p'`
+    if [ "x$LIBS" != "x" ]; then
+	echo "`echo $dylib | sed 's|.*/\(.*\.dylib\)|\1|'` is using:"
+	for lib in $LIBS; do
+	    echo "    $lib"
+	    new_lib=`echo $lib | sed 's|.*/\(.*\.dylib\)|\1|'`
+	    if [ -e  $PD_APP_LIB/$new_lib ]; then
+		echo "$PD_APP_LIB/$new_lib already exists, skipping copy."
+	    else
+		install -vp /usr/local/opt/$lib $PD_APP_LIB
+	    fi
+	    install_name_tool -id @loader_path/$new_lib $PD_APP_LIB/$new_lib
+	    install_name_tool -change /usr/local/opt/$lib @loader_path/$new_lib $dylib
+	done
+	echo " "
+    fi
+done
+
+# seems like we need it one last time! phew...
+for dylib in $PD_APP_LIB/*.dylib; do
+    LIBS=`otool -L $dylib | sed -n 's|.*/usr/local/opt/\(.*\.dylib\).*|\1|p'`
+    if [ "x$LIBS" != "x" ]; then
+	echo "`echo $dylib | sed 's|.*/\(.*\.dylib\)|\1|'` is using:"
+	for lib in $LIBS; do
+	    echo "    $lib"
+	    new_lib=`echo $lib | sed 's|.*/\(.*\.dylib\)|\1|'`
+	    if [ -e  $PD_APP_LIB/$new_lib ]; then
+		echo "$PD_APP_LIB/$new_lib already exists, skipping copy."
+	    else
+		install -vp /usr/local/opt/$lib $PD_APP_LIB
+	    fi
+	    install_name_tool -id @loader_path/$new_lib $PD_APP_LIB/$new_lib
+	    install_name_tool -change /usr/local/opt/$lib @loader_path/$new_lib $dylib
+	done
+	echo " "
+    fi
+done

--- a/liboauth.rb
+++ b/liboauth.rb
@@ -1,0 +1,30 @@
+class Liboauth < Formula
+  desc "C library for the OAuth Core RFC 5849 standard"
+  homepage "http://liboauth.sourceforge.net"
+  url "https://downloads.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz"
+  sha256 "0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f"
+  revision 1
+
+  bottle do
+    cellar :any
+    sha256 "3d5b00cf3fc8ed4032b1e5e618ab0bfbc962414373ac9bf45a5ee883a4277a07" => :yosemite
+    sha256 "9bbd1a6e6cb7c089f3971858b84674545f4125e088072399bace245c29562f03" => :mavericks
+    sha256 "6a022751288301f6cca5cbce0022f8bac7b225df7adfd5b1cbb11a29f01c75ad" => :mountain_lion
+  end
+
+  depends_on "openssl"
+  
+  option :universal
+
+  def install
+    ENV['CC']="gcc -arch i386 -arch x86_64"
+    ENV['CXX']="g++ -arch i386 -arch x86_64"
+    ENV['CPP']="gcc -E" 
+    ENV['CXXCPP']="g++ -E"
+    ENV.universal_binary if build.universal?
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--disable-curl"
+    system "make", "install"
+  end
+end


### PR DESCRIPTION
Hello,

I was having trouble compiling liboauth as universal with the stock homebrew. here is a formula fix for doing this.

i also added a .sh to embed all osx depends from homebrew. I wonder though, does liboauth not rely on openssl? because that is not embedding from some reason....

cheers
mark