### PR TITLE
Allow overriding of path to Makefile.pdlibbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ deken.file = $(lib.name)-v$(lib.version)-($(system)-$(machine)-$(deken.bits))-ex
 deken.tmp = deken-tmp
 deken.folder = $(lib.name)
 
-include pd-lib-builder/Makefile.pdlibbuilder
+PDLIBBUILDER_DIR=pd-lib-builder
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
 deken:
 	mkdir -p "$(deken.tmp)"


### PR DESCRIPTION
when doing a non-recursive checkout, or when downloading the sources as tarball (which does a `git archive`), there will be no `pd-lib-builder/ ` subdirectory.
if the user manages to install pd-lib-builder separately, they could just point the buildsystem to their installation.

e.g. on Debian systems do:

~~~sh
sudo apt-get install pd-lib-builder
make PDLIBBUILDER_DIR=/usr/share/pd-lib-builder/
~~~