### PR TITLE
Exclude files that are only meaningful in a git-repository from 'git-archive'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# exclude files that only make sense in the upstream repository
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
when downloading release tarballs, the archive contains some files that only makes sense in the context of a git repository (sometimes a git-repository on github). some are simply cruft and others might be harmful.

notably

- `.travis-ci.yml` no use when not on github
- `.gitignore`, `.gitsubmodules`,... only useful within a git-repository. if the release tarball is imported in a separate git-repository (e.g. [Debian packaging](https://salsa.debian.org/multimedia-team/pd/pd-purest-json)), these files can be harmful as they shadow changes to the repository.

this PR adds a `gitattributes` file that excludes these files from the tarballs generated with `git archive` (which is used by github to create the downloadable tarballs)