### PR TITLE
code cleanup

### DIFF
--- a/json-help.pd
+++ b/json-help.pd
@@ -1,22 +1,22 @@
 #N canvas 79 63 1143 647 10;
-#X obj 665 397 json-encode;
-#X obj 665 466 json-decode;
-#X obj 51 -13 json-encode;
-#X obj 51 15 json-decode;
-#X text 131 -12 - encodes data into a JSON string.;
-#X text 131 14 - decodes a JSON string to lists.;
-#X msg 646 35 add id 1;
-#X text 643 2 Will add key id and value of 1 to object;
-#X msg 688 65 add name Residuum;
-#X text 714 91 This will add a string with the spaces intact to the
+#X obj 665 417 json-encode;
+#X obj 665 486 json-decode;
+#X obj 51 7 json-encode;
+#X obj 51 35 json-decode;
+#X text 131 8 - encodes data into a JSON string.;
+#X text 131 34 - decodes a JSON string to lists.;
+#X msg 646 55 add id 1;
+#X text 643 22 Will add key id and value of 1 to object;
+#X msg 688 85 add name Residuum;
+#X text 714 111 This will add a string with the spaces intact to the
 JSON object;
-#X msg 752 207 add id 2;
-#X text 749 180 adding a different value will overwrite the previously
+#X msg 752 227 add id 2;
+#X text 749 200 adding a different value will overwrite the previously
 stored one;
-#X msg 478 341 clear;
-#X text 437 310 This will clear the object;
-#X text 794 241 output the value;
-#X msg 795 260 bang;
+#X msg 478 361 clear;
+#X text 437 330 This will clear the object;
+#X text 794 261 output the value;
+#X msg 795 280 bang;
 #N canvas 85 61 536 476 nested-objects 0;
 #X obj -74 -56 json-encode;
 #X obj -74 2 json-decode;
@@ -46,8 +46,8 @@ stored one;
 #X connect 8 0 1 0;
 #X connect 8 1 9 0;
 #X connect 12 0 4 0;
-#X restore 49 424 pd nested-objects;
-#X obj 665 424 t a a;
+#X restore 49 444 pd nested-objects;
+#X obj 665 444 t a a;
 #N canvas 312 61 693 648 about-decoded-json-strings 0;
 #X obj 218 -185 json-encode;
 #X obj 94 -86 json-decode;
@@ -59,12 +59,12 @@ stored one;
 #X obj 218 -159 t a a a;
 #X obj 387 -57 json-decode;
 #X obj 418 87 line;
-#X floatatom 418 120 5 0 0 0 - - -, f 5;
+#X floatatom 418 120 5 0 0 0 - - -;
 #X msg 418 67 \$1 \, \$2 \$3;
 #X obj 418 2 route start end duration;
 #X text 399 -78 wrong;
 #X obj 157 72 line;
-#X floatatom 157 105 5 0 0 0 - - -, f 5;
+#X floatatom 157 105 5 0 0 0 - - -;
 #X obj 157 -29 route start end duration;
 #X obj 157 -58 list trim;
 #X obj 418 -27 list trim;
@@ -115,7 +115,7 @@ the store \, with the left outlet of [json-decode].;
 #X connect 21 0 22 0;
 #X connect 22 0 23 0;
 #X connect 23 0 13 0;
-#X restore 49 447 pd about-decoded-json-strings;
+#X restore 49 467 pd about-decoded-json-strings;
 #N canvas 44 61 450 465 json-arrays 0;
 #X obj 42 73 json-encode;
 #X msg 42 33 clear \, array storage textfile \, array storage couchdb
@@ -142,37 +142,37 @@ the store \, with the left outlet of [json-decode].;
 #X connect 7 1 11 0;
 #X connect 8 0 7 0;
 #X connect 8 1 10 0;
-#X restore 49 472 pd json-arrays;
-#X text 46 401 [json-decode] treats json arrays as a series of objects.
+#X restore 49 492 pd json-arrays;
+#X text 46 421 [json-decode] treats json arrays as a series of objects.
 ;
-#X obj 755 467 print JSON_string;
-#X msg 799 309 write /tmp/test.json;
-#X msg 797 371 read test.json;
-#X text 797 290 write the content as JSON to a file;
-#X text 794 352 read data from a JSON file;
-#X text 46 46 [json-encode] has six methods: add \, array \, clear
+#X obj 755 487 print JSON_string;
+#X msg 799 329 write /tmp/test.json;
+#X msg 797 391 read test.json;
+#X text 797 310 write the content as JSON to a file;
+#X text 794 372 read data from a JSON file;
+#X text 46 66 [json-encode] has six methods: add \, array \, clear
 \, bang \, write and read.;
-#X text 46 112 array adds a new value to an array.;
-#X text 46 130 clear clears the internally stored object.;
-#X text 46 147 bang outputs the stored object as a JSON string.;
-#X text 46 74 add adds a new key/value pair to the internally stored
+#X text 46 132 array adds a new value to an array.;
+#X text 46 150 clear clears the internally stored object.;
+#X text 46 167 bang outputs the stored object as a JSON string.;
+#X text 46 94 add adds a new key/value pair to the internally stored
 object. If you call add with a value that is already a JSON string
 \, then the object will be added as a nested object.;
-#X text 46 165 read reads JSON data from a file. This file must contain
+#X text 46 185 read reads JSON data from a file. This file must contain
 exactly one JSON object \, as [json-encode] only stores one object
 internally.;
-#X text 46 203 write writes the internally stored data as JSON to a
+#X text 46 223 write writes the internally stored data as JSON to a
 file.;
-#X obj 347 227 qlist;
-#X text 46 225 add \, read and write methods work analog to;
-#X obj 49 588 import purest_json;
-#X obj 458 564 print decoding_done;
-#X obj 617 565 print decoded_data;
-#X msg 714 118 add album dss;
-#X msg 734 150 add year 2018;
-#X obj 774 566 print not-a-json-object;
-#X msg 924 401 no json;
-#X text 44 254 [json-decode] will accept a JSON string at its input
+#X obj 347 247 qlist;
+#X text 46 245 add \, read and write methods work analog to;
+#X obj 49 608 import purest_json;
+#X obj 458 584 print decoding_done;
+#X obj 617 585 print decoded_data;
+#X msg 714 138 add album dss;
+#X msg 734 170 add year 2018;
+#X obj 774 586 print not-a-json-object;
+#X msg 924 421 no json;
+#X text 44 274 [json-decode] will accept a JSON string at its input
 and will output the decoded object as a series of lists of key/value
 pairs on the middle outlet. Boolean values of TRUE/FALSE will be translated
 to 1 or 0 \, float and integer values will be output as floats. Nested

--- a/rest-help.pd
+++ b/rest-help.pd
@@ -1,19 +1,19 @@
 #N canvas 220 73 1137 558 10;
-#X text 55 -59 - object for HTTP communication with REST webservices
+#X text 55 21 - object for HTTP communication with REST webservices
 ;
-#X obj 450 -52 import purest_json;
-#X obj 19 -60 rest;
-#X obj 450 390 rest;
-#X text 466 27 By default \, requests do not timeout. To set a maximal
+#X obj 450 28 import purest_json;
+#X obj 19 20 rest;
+#X obj 450 470 rest;
+#X text 466 107 By default \, requests do not timeout. To set a maximal
 time in milliseconds \, set a value with [timeout( message. To clear
 the value and return to the default \, use an empty [timeout( message.
 ;
-#X msg 469 81 timeout 2000;
-#X msg 569 81 timeout;
-#X msg 600 332 sslcheck 0;
-#X msg 692 332 sslcheck 1;
-#X obj 19 -36 oauth;
-#X text 57 -37 - object for HTTP communication with OAuth webservices
+#X msg 469 161 timeout 2000;
+#X msg 569 161 timeout;
+#X msg 600 412 sslcheck 0;
+#X msg 692 412 sslcheck 1;
+#X obj 19 44 oauth;
+#X text 57 43 - object for HTTP communication with OAuth webservices
 ;
 #N canvas 148 110 1044 412 oauth-specific 0;
 #X obj 29 53 oauth http://example.com/ CLIENTKEY CLIENTSECRET ACCESSTOKEN
@@ -72,10 +72,10 @@ or use [init( message.;
 #X connect 10 0 13 0;
 #X connect 10 1 14 0;
 #X connect 11 0 10 0;
-#X restore 196 266 pd oauth-specific;
-#X text 19 -2 Most methods work the same for [rest] and [oauth] \,
+#X restore 196 346 pd oauth-specific;
+#X text 19 78 Most methods work the same for [rest] and [oauth] \,
 only some methods differ. The differences are outlined below.;
-#X obj 22 197 urlparams;
+#X obj 22 277 urlparams;
 #N canvas 137 61 544 367 rest-specific 0;
 #N canvas 492 70 517 474 cookie-auth 0;
 #X text 34 91 This will try to log you in on creation. It will call
@@ -289,12 +289,12 @@ empty init message will clean a previous set base url. The number of
 possible parameters for [rest] and [oauth] differ. You can also use
 four parameters for the [init( message to use basic cookie authentication
 \, see below.;
-#X restore 21 266 pd rest-specific;
-#X text 594 289 By default correct SSL host is checked. Disable check
+#X restore 21 346 pd rest-specific;
+#X text 594 369 By default correct SSL host is checked. Disable check
 by sending sslcheck with a value to 0 \, reenable checking by setting
 the value to 1;
-#X msg 632 160 cancel;
-#X text 637 202 Use this request to test cancelling and timeout: it
+#X msg 632 240 cancel;
+#X text 637 282 Use this request to test cancelling and timeout: it
 will wait for 10 seconds before returning data.;
 #N canvas 385 252 807 334 cancel 0;
 #X obj 105 -51 print data;
@@ -324,16 +324,16 @@ of 20ms is sufficient on my system (TM).;
 #X connect 7 1 3 0;
 #X connect 8 0 7 0;
 #X connect 10 0 6 0;
-#X restore 710 162 pd cancel;
-#X text 628 82 You can cancel a currently executed request by issuing
+#X restore 710 242 pd cancel;
+#X text 628 162 You can cancel a currently executed request by issuing
 [cancel(. If data has been returned already \, but is not output \,
 or output only partially \, outputting the data will still be completed.
 Note \, that cancelling the call may take some time \, so do not try
 to issue a new request immediately. See;
-#X text 19 27 [rest] is an object for communication with REST services.
+#X text 19 107 [rest] is an object for communication with REST services.
 Request methods GET \, POST \, PUT \, DELETE \, HEAD \, OPTIONS \,
 PATCH and TRACE are available.;
-#X text 19 223 HTTP requests are asynchronous. Do not expect a request
+#X text 19 303 HTTP requests are asynchronous. Do not expect a request
 to return data immediately. While one request is processed \, the object
 is blocked.;
 #N canvas 358 174 631 378 download-to-file 0;
@@ -352,8 +352,8 @@ is blocked.;
 #X connect 1 0 0 0;
 #X connect 5 0 0 0;
 #X connect 6 0 0 0;
-#X restore 21 374 pd download-to-file;
-#X text 20 333 More functions:;
+#X restore 21 454 pd download-to-file;
+#X text 20 413 More functions:;
 #N canvas 170 140 678 510 streaming-and-blocking 0;
 #X obj 77 353 rest;
 #X msg 77 142 mode stream;
@@ -375,7 +375,7 @@ You can set the mode even during running requests.;
 #X connect 1 0 0 0;
 #X connect 2 0 0 0;
 #X connect 10 0 0 0;
-#X restore 21 396 pd streaming-and-blocking;
+#X restore 21 476 pd streaming-and-blocking;
 #N canvas 114 149 628 451 setting-headers 0;
 #X obj 76 327 rest;
 #X msg 191 226 GET https://api.github.com/repos/residuum/PuRestJson/contents/Makefile
@@ -397,7 +397,7 @@ values of Accept: headers;
 #X connect 2 0 0 0;
 #X connect 3 0 0 0;
 #X connect 7 0 0 0;
-#X restore 21 351 pd setting-headers;
+#X restore 21 431 pd setting-headers;
 #N canvas 313 165 899 593 proxy 0;
 #X obj 291 442 rest;
 #X obj 301 479 print;
@@ -426,18 +426,18 @@ any parameter to the object.;
 #X connect 6 0 0 0;
 #X connect 7 0 0 0;
 #X connect 13 0 0 0;
-#X restore 21 419 pd proxy;
-#X obj 623 423 print error;
-#X obj 450 422 print done;
-#X obj 532 422 print data;
-#X msg 641 232 GET https://ix.residuum.org/pd/sleep_example.php;
-#X msg 451 -18 GET https://jsonplaceholder.typicode.com/posts;
-#X text 19 117 All requests are issued with [REQUEST_METHOD URL DATA(
+#X restore 21 499 pd proxy;
+#X obj 623 503 print error;
+#X obj 450 502 print done;
+#X obj 532 502 print data;
+#X msg 641 312 GET https://ix.residuum.org/pd/sleep_example.php;
+#X msg 451 62 GET https://jsonplaceholder.typicode.com/posts;
+#X text 19 197 All requests are issued with [REQUEST_METHOD URL DATA(
 where REQUEST_METHOD is the uppercase verb of the method \, URL is
 the request URL \, or the relative server path \, if [url( or initialization
 is used \, and DATA is the upload data for PUT or post data for POST.
 For creating url encoded lists of parameters see;
-#X text 19 70 [oauth] is an object for communication with OAUTH enabled
+#X text 19 150 [oauth] is an object for communication with OAUTH enabled
 webservices. Request methods GET \, POST \, PUT \, DELETE \, HEAD \,
 OPTIONS and TRACE are available.;
 #X connect 3 0 28 0;

--- a/src/inc/string.c
+++ b/src/inc/string.c
@@ -5,7 +5,7 @@ static void string_free(char *string, size_t *strl);
 /* suppresses warning, nothing special */
 #ifndef NO_BACKSLASHES
 /* removes pd added backslashes from string */
-static char *string_remove_backslashes(char *source_string, size_t *memsize);
+static char *string_remove_backslashes(const char *source_string, size_t *memsize);
 #endif
 
 /* begin implementations */
@@ -32,9 +32,13 @@ static void string_free(char *string, size_t *const strl) {
 
 /* suppresses warning, nothing special */
 #ifndef NO_BACKSLASHES
-static char *string_remove_backslashes(char *const source_string, size_t *const memsize) {
+static char *string_remove_backslashes(const char *const _source_string, size_t *const memsize) {
 	char *cleaned_string = NULL;
-	const size_t len_src = strlen(source_string);
+	char source_string_stack[MAXPDSTRING];
+	const size_t len_src = strlen(_source_string);
+	size_t sslen = 0;
+	char*source_string = (len_src<MAXPDSTRING)?source_string_stack:string_create(&sslen, len_src);
+	strcpy(source_string, _source_string);
 
 	cleaned_string = string_create(memsize, len_src);
 	if (cleaned_string == NULL) {
@@ -55,6 +59,8 @@ static char *string_remove_backslashes(char *const source_string, size_t *const 
 			segment = strtok(NULL, masking);
 		}
 	}
+	if(source_string != source_string_stack)
+		string_free(source_string, &sslen);
 	return (cleaned_string);
 }
 #endif

--- a/src/json-decode.c
+++ b/src/json-decode.c
@@ -39,6 +39,16 @@ struct _json_decode {
 	t_outlet *error_outlet;
 };
 
+/* constructor */
+static void *json_decode_new(const t_symbol *sel, const int argc, const t_atom *argv);
+
+/* string input */
+static void json_decode_string(t_json_decode *x, const t_symbol *data);
+
+/* list input */
+static void json_decode_list(t_json_decode *x, const t_symbol *sel, const int argc, t_atom *argv);
+
+
 /* outputs json object at outlets */
 static void jdec_output_object(json_object *jobj, t_outlet *data_outlet, t_outlet *done_outlet);
 /* outputs json array at outlets */

--- a/src/json-decode.c
+++ b/src/json-decode.c
@@ -192,7 +192,7 @@ void *json_decode_new(const t_symbol *const sel, const int argc, const t_atom *c
 }
 
 void json_decode_string(t_json_decode *const jdec, const t_symbol *const data) {
-	char *const original_string = data->s_name;
+	const char *const original_string = data->s_name;
 
 	if (original_string && strlen(original_string)) {
 		size_t memsize = 0;

--- a/src/json-decode.c
+++ b/src/json-decode.c
@@ -79,7 +79,7 @@ static void jdec_output_object(json_object *const jobj, t_outlet *const data_out
 				case json_type_int:
 					SETFLOAT(&out_data[1], json_object_get_int(val));
 					break;
-				case json_type_string: 
+				case json_type_string:
 					SETSYMBOL(&out_data[1], gensym(json_object_get_string(val)));
 					break;
 				case json_type_object:
@@ -148,7 +148,7 @@ static void jdec_output(json_object *const jobj, t_outlet *const data_outlet, t_
 		case json_type_object:
 			jdec_output_object(jobj, data_outlet, done_outlet);
 			break;
-		case json_type_array: 
+		case json_type_array:
 			jdec_output_array(jobj, data_outlet, done_outlet, error_outlet);
 			break;
 		default:

--- a/src/json-decode.h
+++ b/src/json-decode.h
@@ -32,12 +32,3 @@ THE SOFTWARE.
 /* [json-decode] */
 struct _json_decode;
 typedef struct _json_decode t_json_decode;
-
-/* constructor */
-APIEXPORT void APICALL *json_decode_new(const t_symbol *sel, const int argc, const t_atom *argv);
-
-/* string input */
-APIEXPORT void APICALL json_decode_string(t_json_decode *x, const t_symbol *data);
-
-/* list input */
-APIEXPORT void APICALL json_decode_list(t_json_decode *x, const t_symbol *sel, const int argc, t_atom *argv);

--- a/src/json-encode.c
+++ b/src/json-encode.c
@@ -44,6 +44,25 @@ struct _json_encode {
 	t_canvas *x_canvas; /* needed for getting file names */
 };
 
+
+/* constructor */
+static void *json_encode_new(const t_symbol *sel, const int argc, const t_atom *argv);
+/* destructor */
+static void json_encode_free(t_json_encode *x, const t_symbol *sel, const int argc, const t_atom *argv);
+
+/* bang and output */
+static void json_encode_bang(t_json_encode *x);
+/* add value */
+static void json_encode_add(t_json_encode *x, const t_symbol *sel, const int argc, t_atom *argv);
+/* add value to array */
+static void json_encode_array(t_json_encode *x, const t_symbol *sel, const int argc, t_atom *argv);
+/* read json file */
+static void json_encode_read(t_json_encode *x, const t_symbol *filename);
+/* write json file */
+static void json_encode_write(t_json_encode *x, const t_symbol *filename);
+/* clear stored json data */
+static void json_encode_clear(t_json_encode *x, const t_symbol *sel, const int argc, const t_atom *argv);
+
 /* gets json object */
 static json_object *jenc_create_object(const struct _v *value);
 /* loads json object */

--- a/src/json-encode.c
+++ b/src/json-encode.c
@@ -83,7 +83,7 @@ static json_object *jenc_create_object(const struct _v *const value) {
 		object = json_object_new_double(value->val.f);
 	} else if (value->type == int_val) {
 		object = json_object_new_int(value->val.i);
-		/* if stored value is string is starting with { and ending with }, 
+		/* if stored value is string is starting with { and ending with },
 		   then create a json object from it. */
 	} else if (value->val.s[0] == '{' && value->val.s[strlen(value->val.s) - 1] == '}') {
 		char *parsed_string;
@@ -106,26 +106,26 @@ static void jenc_load_json_object(const t_json_encode *const jenc, json_object *
 
 		switch (inner_type) {
 			case json_type_boolean:
-				kvp_add_simple((struct _kvp_store *)jenc, key, 
+				kvp_add_simple((struct _kvp_store *)jenc, key,
 						kvp_val_create(NULL, json_object_get_boolean(val) ? 1 : 0));
 				break;
 			case json_type_double:
-				kvp_add_simple((struct _kvp_store *)jenc, key, 
+				kvp_add_simple((struct _kvp_store *)jenc, key,
 						kvp_val_create(NULL, json_object_get_double(val)));
 				break;
 			case json_type_int:
-				kvp_add_simple((struct _kvp_store *)jenc, key, 
+				kvp_add_simple((struct _kvp_store *)jenc, key,
 						kvp_val_create(NULL, json_object_get_int(val)));
 				break;
 			case json_type_string:
-				value = string_create(&value_len, snprintf(NULL, 0, "%s", 
+				value = string_create(&value_len, snprintf(NULL, 0, "%s",
 							json_object_get_string(val)));
 				sprintf(value, "%s", json_object_get_string(val));
 				kvp_add_simple((struct _kvp_store *)jenc, key, kvp_val_create(value, 0));
 				string_free(value, &value_len);
 				break;
 			case json_type_object:
-				value = string_create(&value_len, snprintf(NULL, 0, "%s", 
+				value = string_create(&value_len, snprintf(NULL, 0, "%s",
 							json_object_get_string(val)));
 				sprintf(value, "%s", json_object_get_string(val));
 				kvp_add_simple((struct _kvp_store *)jenc, key, kvp_val_create(value, 0));
@@ -136,11 +136,11 @@ static void jenc_load_json_object(const t_json_encode *const jenc, json_object *
 				for (int i = 0; i < array_len; i++) {
 					json_object *array_member = json_object_array_get_idx(val, i);
 					if (array_member != NULL) {
-						value = string_create(&value_len, 
+						value = string_create(&value_len,
 								snprintf(NULL, 0, "%s",
 									json_object_get_string(array_member)));
 						sprintf(value, "%s", json_object_get_string(array_member));
-						kvp_add_array((struct _kvp_store *)jenc, key, 
+						kvp_add_array((struct _kvp_store *)jenc, key,
 								kvp_val_create(value, 0));
 						string_free(value, &value_len);
 					}
@@ -164,7 +164,7 @@ static void jenc_load_json_data(t_json_encode *const jenc, json_object *const jo
 		case json_type_object:
 			jenc_load_json_object(jenc, jobj);
 			break;
-		default: 
+		default:
 			pd_error(jenc, "This JSON data cannot be represented internally, sorry.");
 			break;
 	}
@@ -182,7 +182,7 @@ static json_object *jenc_get_array_value(struct _kvp *item) {
 		value = value->next;
 		array_member = jenc_create_object(value);
 		json_object_array_add(json_value, array_member);
-	}	
+	}
 
 	return json_value;
 }
@@ -204,7 +204,7 @@ static t_symbol *jenc_get_json_symbol(t_json_encode *const jenc) {
 		} else {
 			value = jenc_create_object(it->value);
 		}
-		json_object_object_add(jobj, it->key, value); 
+		json_object_object_add(jobj, it->key, value);
 	}
 	json_symbol = gensym(json_object_to_json_string(jobj));
 	json_object_put(jobj);
@@ -260,7 +260,7 @@ void setup_json0x2dencode(void) {
 	class_sethelpsymbol(json_encode_class, gensym("json"));
 }
 
-void json_encode_free (t_json_encode *const jenc, const t_symbol *const sel, const int argc, 
+void json_encode_free (t_json_encode *const jenc, const t_symbol *const sel, const int argc,
 		const t_atom *const argv) {
 
 	(void) sel;
@@ -358,7 +358,7 @@ void *json_encode_new(const t_symbol *const sel, const int argc, const t_atom *c
 	return (void *)jenc;
 }
 
-void json_encode_clear(t_json_encode *const jenc, const t_symbol *const sel, const int argc, 
+void json_encode_clear(t_json_encode *const jenc, const t_symbol *const sel, const int argc,
 		const t_atom *const argv) {
 
 	(void) sel;

--- a/src/json-encode.h
+++ b/src/json-encode.h
@@ -38,20 +38,3 @@ THE SOFTWARE.
 struct _json_encode;
 typedef struct _json_encode t_json_encode;
 
-/* constructor */
-APIEXPORT void APICALL *json_encode_new(const t_symbol *sel, const int argc, const t_atom *argv);
-/* destructor */
-APIEXPORT void APICALL json_encode_free(t_json_encode *x, const t_symbol *sel, const int argc, const t_atom *argv);
-
-/* bang and output */
-APIEXPORT void APICALL json_encode_bang(t_json_encode *x);
-/* add value */
-APIEXPORT void APICALL json_encode_add(t_json_encode *x, const t_symbol *sel, const int argc, t_atom *argv);
-/* add value to array */
-APIEXPORT void APICALL json_encode_array(t_json_encode *x, const t_symbol *sel, const int argc, t_atom *argv);
-/* read json file */
-APIEXPORT void APICALL json_encode_read(t_json_encode *x, const t_symbol *filename);
-/* write json file */
-APIEXPORT void APICALL json_encode_write(t_json_encode *x, const t_symbol *filename);
-/* clear stored json data */
-APIEXPORT void APICALL json_encode_clear(t_json_encode *x, const t_symbol *sel, const int argc, const t_atom *argv);

--- a/src/json-encode.h
+++ b/src/json-encode.h
@@ -37,4 +37,3 @@ THE SOFTWARE.
 /* [json-encode] */
 struct _json_encode;
 typedef struct _json_encode t_json_encode;
-

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -190,7 +190,7 @@ void oauth_setup(void) {
 }
 
 void oauth_command(t_oauth *const oauth, const t_symbol *const sel, const int argc, t_atom *argv) {
-	char *req_type;
+	const char *req_type;
 	char path[MAXPDSTRING];
 	size_t req_path_len;
 	char *req_path;

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -108,17 +108,17 @@ static void oauth_set_init(t_oauth *const oauth, const int argc, t_atom *const a
 		case 0:
 			break;
 		case 5:
-			oauth->oauth.token_key = ctw_set_param((struct _ctw *)oauth, argv + 3, 
+			oauth->oauth.token_key = ctw_set_param((struct _ctw *)oauth, argv + 3,
 					&oauth->oauth.token_key_len, "Token key cannot be set.");
-			oauth->oauth.token_secret = ctw_set_param((struct _ctw *)oauth, argv + 4, 
+			oauth->oauth.token_secret = ctw_set_param((struct _ctw *)oauth, argv + 4,
 					&oauth->oauth.token_secret_len, "Token secret cannot be set.");
 			/* FALLTHRU */
 		case 3:
-			oauth->common.base_url = ctw_set_param((struct _ctw *)oauth, argv, 
+			oauth->common.base_url = ctw_set_param((struct _ctw *)oauth, argv,
 					&oauth->common.base_url_len, "Base URL cannot be set.");
-			oauth->oauth.client_key = ctw_set_param((struct _ctw *)oauth, argv + 1, 
+			oauth->oauth.client_key = ctw_set_param((struct _ctw *)oauth, argv + 1,
 					&oauth->oauth.client_key_len, "Client key cannot be set.");
-			oauth->oauth.client_secret = ctw_set_param((struct _ctw *)oauth, argv + 2, 
+			oauth->oauth.client_secret = ctw_set_param((struct _ctw *)oauth, argv + 2,
 					&oauth->oauth.client_secret_len, "Client secret cannot be set.");
 			break;
 		default:
@@ -233,7 +233,7 @@ void oauth_command(t_oauth *const oauth, const t_symbol *const sel, const int ar
 			cleaned_parameters = string_remove_backslashes(parameters, &memsize);
 		}
 	}
-	req_path = string_create(&req_path_len, 
+	req_path = string_create(&req_path_len,
 			oauth->common.base_url_len + strlen(path) + memsize + 1);
 	if (oauth->common.base_url != NULL) {
 		strcpy(req_path, oauth->common.base_url);
@@ -252,7 +252,7 @@ void oauth_command(t_oauth *const oauth, const t_symbol *const sel, const int ar
 		req_url= oauth_sign_url2(req_path, &postargs, oauth->oauth.method, oauth->common.req_type,
 				oauth->oauth.client_key,
 				oauth->oauth.method == OA_RSA ? oauth->oauth.rsa_key : oauth->oauth.client_secret,
-				oauth->oauth.token_key, 
+				oauth->oauth.token_key,
 				oauth->oauth.method == OA_RSA ? NULL : oauth->oauth.token_secret);
 		oauth->common.parameters = string_create(&oauth->common.parameters_len, strlen(postargs));
 		strcpy(oauth->common.parameters, postargs);
@@ -260,7 +260,7 @@ void oauth_command(t_oauth *const oauth, const t_symbol *const sel, const int ar
 		req_url= oauth_sign_url2(req_path, NULL, oauth->oauth.method, oauth->common.req_type,
 				oauth->oauth.client_key,
 				oauth->oauth.method == OA_RSA ? oauth->oauth.rsa_key : oauth->oauth.client_secret,
-				oauth->oauth.token_key, 
+				oauth->oauth.token_key,
 				oauth->oauth.method == OA_RSA ? NULL : oauth->oauth.token_secret);
 		oauth->common.parameters = string_create(&oauth->common.parameters_len, 0);
 	}
@@ -303,8 +303,8 @@ void oauth_method(t_oauth *const oauth, const t_symbol *const sel, const int arg
 		}
 	} else if (strcmp(method_name, "RSA") == 0) {
 		if (LIBOAUTH_VERSION_MAJOR < 1
-				|| (LIBOAUTH_VERSION_MAJOR == 1 
-					&& LIBOAUTH_VERSION_MINOR == 0 
+				|| (LIBOAUTH_VERSION_MAJOR == 1
+					&& LIBOAUTH_VERSION_MINOR == 0
 					&& LIBOAUTH_VERSION_MICRO == 0)) {
 			pd_error(oauth, "RSA-SHA1 is not supported by liboauth version < 1.0.1.");
 			return;
@@ -327,7 +327,7 @@ void oauth_init(t_oauth *const oauth, const t_symbol *const sel, const int argc,
 	if (oauth->common.locked) {
 		post("oauth object is performing request and locked.");
 	} else {
-		oauth_set_init(oauth, argc, argv); 
+		oauth_set_init(oauth, argc, argv);
 	}
 }
 
@@ -363,7 +363,7 @@ void oauth_header(t_oauth *const oauth, const t_symbol *const sel, const int arg
 	ctw_add_header((struct _ctw *)oauth, argc, argv);
 }
 
-void oauth_clear_headers(t_oauth *const oauth, const t_symbol *const sel, const int argc, 
+void oauth_clear_headers(t_oauth *const oauth, const t_symbol *const sel, const int argc,
 		const t_atom *const argv) {
 
 	(void) sel;
@@ -402,8 +402,8 @@ void *oauth_new(const t_symbol *const sel, const int argc, t_atom *const argv) {
 	ctw_init((struct _ctw *)oauth);
 	ctw_set_timeout((struct _ctw *)oauth, 0);
 
-	oauth_set_init(oauth, 0, argv); 
-	oauth_set_init(oauth, argc, argv); 
+	oauth_set_init(oauth, 0, argv);
+	oauth_set_init(oauth, argc, argv);
 	oauth->oauth.method = OA_HMAC;
 	oauth->oauth.rsa_key_len = 0;
 

--- a/src/oauth.c
+++ b/src/oauth.c
@@ -54,6 +54,36 @@ struct _oauth {
 	} oauth;
 };
 
+
+/* constructor */
+static void *oauth_new(const t_symbol *sel, const int argc, t_atom *argv);
+/* destructor */
+static void oauth_free(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
+
+/* HTTP request */
+static void oauth_command(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* set or clear timeout */
+static void oauth_timeout(t_oauth *oauth, const t_floatarg f);
+/* inits object and sets parameters */
+static void oauth_init(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* OAuth singature method */
+static void oauth_method(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets or clears check of SSL certificate */
+static void oauth_sslcheck(t_oauth *oauth, const t_floatarg f);
+/* cancel request */
+static void oauth_cancel(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
+/* set header */
+static void oauth_header(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* clear header */
+static void oauth_clear_headers(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
+/* sets output file */
+static void oauth_file(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets mode to HTTP streaming or blocking */
+static void oauth_mode(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets proxy */
+static void oauth_proxy(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
+
+
 /* frees data */
 static void oauth_free_inner(t_oauth *oauth, const short free_rsa);
 /* initialises object */

--- a/src/oauth.h
+++ b/src/oauth.h
@@ -34,31 +34,3 @@ THE SOFTWARE.
 
 struct _oauth;
 typedef struct _oauth t_oauth;
-
-/* constructor */
-APIEXPORT void APICALL *oauth_new(const t_symbol *sel, const int argc, t_atom *argv);
-/* destructor */
-APIEXPORT void APICALL oauth_free(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
-
-/* HTTP request */
-APIEXPORT void APICALL oauth_command(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv); 
-/* set or clear timeout */
-APIEXPORT void APICALL oauth_timeout(t_oauth *oauth, const t_floatarg f);
-/* inits object and sets parameters */
-APIEXPORT void APICALL oauth_init(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
-/* OAuth singature method */
-APIEXPORT void APICALL oauth_method(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets or clears check of SSL certificate */
-APIEXPORT void APICALL oauth_sslcheck(t_oauth *oauth, const t_floatarg f);
-/* cancel request */
-APIEXPORT void APICALL oauth_cancel(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
-/* set header */
-APIEXPORT void APICALL oauth_header(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
-/* clear header */
-APIEXPORT void APICALL oauth_clear_headers(t_oauth *oauth, const t_symbol *sel, const int argc, const t_atom *argv);
-/* sets output file */
-APIEXPORT void APICALL oauth_file(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets mode to HTTP streaming or blocking */
-APIEXPORT void APICALL oauth_mode(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets proxy */
-APIEXPORT void APICALL oauth_proxy(t_oauth *oauth, const t_symbol *sel, const int argc, t_atom *argv);

--- a/src/purest_json.h
+++ b/src/purest_json.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 	#define APIEXPORT __declspec(dllexport)
 	#define APICALL __cdecl
 	#define MYERROR(...) post(__VA_ARGS__)
-#else 
+#else
 	#define APIEXPORT
 	#define APICALL
 	#define MYERROR(...) error(__VA_ARGS__)
@@ -67,5 +67,5 @@ APIEXPORT void APICALL setup_json0x2ddecode(void);
 /* [urlparams] */
 APIEXPORT void APICALL urlparams_setup(void);
 
-/* general */ 
+/* general */
 APIEXPORT void APICALL purest_json_setup(void);

--- a/src/purest_json.h
+++ b/src/purest_json.h
@@ -34,7 +34,11 @@ THE SOFTWARE.
 	#define APICALL __cdecl
 	#define MYERROR(...) post(__VA_ARGS__)
 #else
-	#define APIEXPORT
+	#if defined(__GNUC__) && __GNUC__>=4
+		#define APIEXPORT extern __attribute__ ((visibility("default")))
+	#else
+		#define APIEXPORT
+	#endif
 	#define APICALL
 	#define MYERROR(...) error(__VA_ARGS__)
 	#ifdef __APPLE__

--- a/src/rest.c
+++ b/src/rest.c
@@ -49,6 +49,33 @@ struct _rest {
 
 static t_class *rest_class;
 
+/* constructor */
+static void *rest_new(t_symbol *sel, const int argc, t_atom *argv);
+/* destructor */
+static void rest_free(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
+
+/* HTTP request */
+static void rest_command(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+/* set or clear timeout */
+static void rest_timeout(t_rest *rest, const t_floatarg f);
+/* inits object and sets parameters */
+static void rest_init(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets or clears check of SSL certificate */
+static void rest_sslcheck(t_rest *rest, const t_floatarg f);
+/* cancel request */
+static void rest_cancel(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
+/* set header */
+static void rest_header(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+/* clear header */
+static void rest_clear_headers(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
+/* sets output file */
+static void rest_file(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets mode to HTTP streaming or blocking */
+static void rest_mode(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+/* sets proxy */
+static void rest_proxy(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
+
+
 /* frees data */
 static void rest_free_inner(t_rest *rest);
 /* extracts cookie data */

--- a/src/rest.c
+++ b/src/rest.c
@@ -107,7 +107,7 @@ static void rest_extract_token(t_rest *const rest, struct _memory_struct *const 
 				while (cookie_params != NULL) {
 					if (strlen(cookie_params)) {
 						rest->common.auth_token = string_create(
-								&rest->common.auth_token_len, 
+								&rest->common.auth_token_len,
 								strlen(cookie_params));
 						strcpy(rest->common.auth_token, cookie_params);
 						break;
@@ -137,9 +137,9 @@ static void rest_process_auth_data(t_rest *const rest, struct _memory_struct *co
 				} else {
 					t_atom http_status_data[2];
 					SETFLOAT(&http_status_data[0], (float)http_status);
-					SETSYMBOL(&http_status_data[1], 
+					SETSYMBOL(&http_status_data[1],
 							gensym(curl_easy_strerror(msg->data.result)));
-					pd_error(rest, "Error while performing request: %s.", 
+					pd_error(rest, "Error while performing request: %s.",
 							curl_easy_strerror(msg->data.result));
 					outlet_list(rest->common.error_out, &s_list, 2, &http_status_data[0]);
 				}
@@ -154,7 +154,7 @@ static void *rest_get_auth_token(void *const thread_args) {
 	t_rest *const rest = thread_args;
 
 	/* length + name=&password=*/
-	rest->common.parameters = string_create(&rest->common.parameters_len, 
+	rest->common.parameters = string_create(&rest->common.parameters_len,
 			rest->cookie.username_len + rest->cookie.password_len + 17);
 	if (rest->common.parameters != NULL) {
 		strcpy(rest->common.parameters, "name=");
@@ -162,7 +162,7 @@ static void *rest_get_auth_token(void *const thread_args) {
 		strcat(rest->common.parameters, "&password=");
 		strcat(rest->common.parameters, rest->cookie.password);
 	}
-	rest->common.complete_url = string_create(&rest->common.complete_url_len, 
+	rest->common.complete_url = string_create(&rest->common.complete_url_len,
 			rest->common.base_url_len + rest->cookie.login_path_len);
 	strcpy(rest->common.complete_url, rest->common.base_url);
 	strcat(rest->common.complete_url, rest->cookie.login_path);
@@ -204,18 +204,18 @@ static void rest_set_init(t_rest *const rest, const int argc, t_atom *const argv
 		case 0:
 			break;
 		case 1:
-			rest->common.base_url = ctw_set_param((struct _ctw *)rest, argv, &rest->common.base_url_len, 
+			rest->common.base_url = ctw_set_param((struct _ctw *)rest, argv, &rest->common.base_url_len,
 					"Base URL cannot be set.");
 			break;
 		case 4:
 			rest->common.locked = 1;
-			rest->common.base_url = ctw_set_param((struct _ctw *)rest, argv, &rest->common.base_url_len, 
+			rest->common.base_url = ctw_set_param((struct _ctw *)rest, argv, &rest->common.base_url_len,
 					"Base URL cannot be set.");
-			rest->cookie.login_path = ctw_set_param((struct _ctw *)rest, argv + 1, 
+			rest->cookie.login_path = ctw_set_param((struct _ctw *)rest, argv + 1,
 					&rest->cookie.login_path_len, "Cookie path cannot be set.");
 			rest->cookie.username = ctw_set_param((struct _ctw *)rest, argv + 2, &rest->cookie.username_len,
 					"Username cannot be set.");
-			rest->cookie.password = ctw_set_param((struct _ctw *)rest, argv + 3, &rest->cookie.password_len, 
+			rest->cookie.password = ctw_set_param((struct _ctw *)rest, argv + 3, &rest->cookie.password_len,
 					"Password cannot be set.");
 			string_free(rest->common.auth_token, &rest->common.auth_token_len);
 			ctw_thread_exec((void *)rest, rest_get_auth_token);
@@ -300,7 +300,7 @@ void rest_init(t_rest *const rest, const t_symbol *const sel, const int argc, t_
 	if (rest->common.locked) {
 		post("rest object is performing request and locked.");
 	} else {
-		rest_set_init(rest, argc, argv); 
+		rest_set_init(rest, argc, argv);
 	}
 }
 
@@ -374,8 +374,8 @@ void *rest_new(t_symbol *const sel, const int argc, t_atom *const argv) {
 	ctw_init((struct _ctw *)rest);
 	ctw_set_timeout((struct _ctw *)rest, 0);
 
-	rest_set_init(rest, 0, argv); 
-	rest_set_init(rest, argc, argv); 
+	rest_set_init(rest, 0, argv);
+	rest_set_init(rest, argc, argv);
 
 	outlet_new(&rest->common.x_ob, &s_bang);
 	rest->common.data_out = outlet_new(&rest->common.x_ob, NULL);

--- a/src/rest.h
+++ b/src/rest.h
@@ -33,29 +33,3 @@ THE SOFTWARE.
 
 struct _rest;
 typedef struct _rest t_rest;
-
-/* constructor */
-APIEXPORT void APICALL *rest_new(t_symbol *sel, const int argc, t_atom *argv);
-/* destructor */
-APIEXPORT void APICALL rest_free(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
-
-/* HTTP request */
-APIEXPORT void APICALL rest_command(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv); 
-/* set or clear timeout */
-APIEXPORT void APICALL rest_timeout(t_rest *rest, const t_floatarg f);
-/* inits object and sets parameters */
-APIEXPORT void APICALL rest_init(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets or clears check of SSL certificate */
-APIEXPORT void APICALL rest_sslcheck(t_rest *rest, const t_floatarg f);
-/* cancel request */
-APIEXPORT void APICALL rest_cancel(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
-/* set header */
-APIEXPORT void APICALL rest_header(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
-/* clear header */
-APIEXPORT void APICALL rest_clear_headers(t_rest *rest, const t_symbol *sel, const int argc, const t_atom *argv);
-/* sets output file */
-APIEXPORT void APICALL rest_file(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets mode to HTTP streaming or blocking */
-APIEXPORT void APICALL rest_mode(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);
-/* sets proxy */
-APIEXPORT void APICALL rest_proxy(t_rest *rest, const t_symbol *sel, const int argc, t_atom *argv);

--- a/src/urlparams.c
+++ b/src/urlparams.c
@@ -41,6 +41,18 @@ struct _urlparams {
 	struct _kvp_store storage;
 };
 
+/* constructor */
+static void *urlparams_new(const t_symbol *sel, const int argc, const t_atom *argv);
+/* destructor */
+static void urlparams_free(t_urlparams *x, const t_symbol *sel, const int argc, const t_atom *argv);
+
+/* bang and output */
+static void urlparams_bang(t_urlparams *x);
+/* add value */
+static void urlparams_add(t_urlparams *x, const t_symbol *sel, const int argc, t_atom *argv);
+/* clear stored values */
+static void urlparams_clear(t_urlparams *x, const t_symbol *sel, const int argc, const t_atom *argv);
+
 /* converts char to hex represenstation for url encoding */
 static char urlp_tohex(const char code);
 /* url encodes a string */

--- a/src/urlparams.h
+++ b/src/urlparams.h
@@ -35,15 +35,3 @@ THE SOFTWARE.
 /* [urlparams] */
 struct _urlparams;
 typedef struct _urlparams t_urlparams;
-
-/* constructor */
-APIEXPORT void APICALL *urlparams_new(const t_symbol *sel, const int argc, const t_atom *argv);
-/* destructor */
-APIEXPORT void APICALL urlparams_free(t_urlparams *x, const t_symbol *sel, const int argc, const t_atom *argv);
-
-/* bang and output */
-APIEXPORT void APICALL urlparams_bang(t_urlparams *x);
-/* add value */
-APIEXPORT void APICALL urlparams_add(t_urlparams *x, const t_symbol *sel, const int argc, t_atom *argv);
-/* clear stored values */
-APIEXPORT void APICALL urlparams_clear(t_urlparams *x, const t_symbol *sel, const int argc, const t_atom *argv);

--- a/travis-build/_debootstrap_before_install.sh
+++ b/travis-build/_debootstrap_before_install.sh
@@ -19,4 +19,5 @@ sudo chroot ${CHROOTDIR} bash -c "apt-get update"
 sudo chroot ${CHROOTDIR} bash -c "apt-get install -qq -y build-essential \
 	puredata-dev libjson-c-dev libcurl4-openssl-dev liboauth-dev zip"
 
+pip install --upgrade pip
 pip install grip beautifulsoup4 lxml --user

--- a/travis-build/_win_before_install.sh
+++ b/travis-build/_win_before_install.sh
@@ -54,4 +54,5 @@ if [ "$PD_DIR" != "/tmp/$PD_UNZIP_PATH" ]; then
 	mv /tmp/${PD_UNZIP_PATH} ${PD_DIR}
 fi
 
+pip install --upgrade pip
 pip install grip beautifulsoup4 lxml --user

--- a/travis-build/linux64_before_install.sh
+++ b/travis-build/linux64_before_install.sh
@@ -2,4 +2,5 @@
 sudo apt-get update
 sudo apt-get -y install puredata-dev libjson-c-dev libcurl4-openssl-dev liboauth-dev zip
 
+pip install --upgrade pip
 pip install grip beautifulsoup4 lxml --user

--- a/urlparams-help.pd
+++ b/urlparams-help.pd
@@ -1,29 +1,28 @@
 #N canvas 44 51 687 503 10;
-#X declare -lib purest_json;
-#X msg 211 110 add id 1;
-#X text 208 77 Will add key id and value of 1 to object;
-#X msg 253 140 add name Residuum;
-#X msg 299 236 add year 2011;
-#X msg 317 282 add id 2;
-#X msg 23 330 clear;
-#X text 22 305 This will clear the object;
-#X text 359 316 output the value;
-#X msg 360 335 bang;
-#X obj 480 2 import purest_json;
-#X obj 47 -14 urlparams;
-#X obj 229 374 urlparams;
-#X text 43 14 [urlparams] has three methods: add \, clear and bang.
+#X msg 211 140 add id 1;
+#X text 208 107 Will add key id and value of 1 to object;
+#X msg 253 170 add name Residuum;
+#X msg 299 266 add year 2011;
+#X msg 317 312 add id 2;
+#X msg 23 360 clear;
+#X text 22 335 This will clear the object;
+#X text 359 346 output the value;
+#X msg 360 365 bang;
+#X obj 480 32 import purest_json;
+#X obj 47 16 urlparams;
+#X obj 229 404 urlparams;
+#X text 43 44 [urlparams] has three methods: add \, clear and bang.
 add adds a new key/value pair to the internally stored object. clear
 clears the internally stored object. bang outputs the stored object
 as urlencoded parameter string.;
-#X text 279 166 This will add a string with url encoded spaces and
+#X text 279 196 This will add a string with url encoded spaces and
 special characters;
-#X obj 229 409 print;
-#X msg 279 194 add anothername who will tweet to @residuummuc with
+#X obj 229 439 print;
+#X msg 279 224 add anothername who will tweet to @residuummuc with
 hashtag #Pd?;
-#X text 127 -13 - create a list of URL encoded parameters for request
+#X text 127 17 - create a list of URL encoded parameters for request
 parameters.;
-#X text 314 255 adding a different value will overwrite the previously
+#X text 314 285 adding a different value will overwrite the previously
 stored one;
 #X connect 0 0 11 0;
 #X connect 2 0 11 0;


### PR DESCRIPTION
some code-cleanup

- delete trailing whitespace in .c/.h files
- adjust to the fact that `t_symbol.s_name` is really `const char*` (it has always been considered immutable, but the type was wrong until Pd-0.48 or so)
- have string_remove_backslashes() take a (const char*) is source string (so we can pass `t_symbol.s_name`)
- don't export the callback functions (instead set them to `static`) #54 
- use `APIEXPORT` to set `visibility=default` on gcc (to be on-par with MSVC's `__declspec(dllexport)`)
- shift the Pd-patch contents so they don't show up outside of the window (and get rid of scrollbars)